### PR TITLE
Implement Command & Journal agent

### DIFF
--- a/docs/PHASE1_IMPLEMENTATION_PLAN.md
+++ b/docs/PHASE1_IMPLEMENTATION_PLAN.md
@@ -26,7 +26,7 @@
 - Implement user-facing handlers in `src/bot/handlers.py`, including error handling and friendly messages for unknown commands.
 - Add `/start` and `/help` responses with usage examples.
 
-### 2) Command & Journal Agent
+### 2) Command & Journal Agent *(Complete)*
 - Implement parsing helpers in `src/bot/parsing.py` (command argument extraction, tag parsing, entry normalization).
 - Implement core command functions in `src/bot/commands.py`:
   - `/log`, `/task`, `/idea` → normalize entry types, extract tags, build record, call storage, return confirmation.

--- a/src/bot/parsing.py
+++ b/src/bot/parsing.py
@@ -1,5 +1,6 @@
 import re
-from typing import List
+from datetime import datetime
+from typing import Dict, List
 
 TAG_PATTERN = re.compile(r"#(\w+)")
 
@@ -8,3 +9,40 @@ def extract_tags(text: str) -> List[str]:
     """Extract hashtags from a text string."""
 
     return [f"#{tag}" for tag in TAG_PATTERN.findall(text)]
+
+
+def extract_command_argument(message_text: str) -> str:
+    """Return the text following the command name.
+
+    Telegram sends the full command (e.g., "/log something great"). This helper
+    discards the command itself and returns the remainder for further parsing.
+    """
+
+    if not message_text:
+        return ""
+
+    parts = message_text.split(maxsplit=1)
+    if len(parts) == 1:
+        return ""
+
+    return parts[1].strip()
+
+
+def normalize_entry(
+    text: str,
+    entry_type: str,
+    tags: List[str],
+    source: str = "telegram",
+    timestamp: datetime | None = None,
+) -> Dict[str, str]:
+    """Create a normalized record ready for storage or display."""
+
+    timestamp = timestamp or datetime.utcnow()
+    return {
+        "timestamp": timestamp.isoformat(),
+        "date": timestamp.date().isoformat(),
+        "type": entry_type,
+        "text": text.strip(),
+        "tags": " ".join(tags),
+        "source": source,
+    }

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,88 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from src.bot import commands
+
+
+def _make_context(storage_client=None):
+    application = SimpleNamespace(bot_data={})
+    if storage_client:
+        application.bot_data["storage_client"] = storage_client
+    return SimpleNamespace(application=application)
+
+
+def _make_update(text: str):
+    message = SimpleNamespace(text=text, reply_text=AsyncMock())
+    return SimpleNamespace(message=message)
+
+
+def test_log_requires_text():
+    update = _make_update("/log")
+    context = _make_context()
+
+    asyncio.run(commands.log_accomplishment(update, context))
+
+    update.message.reply_text.assert_called_once_with(
+        "Please include some text after the command to log it."
+    )
+
+
+def test_log_rejects_long_text():
+    update = _make_update("/log " + "x" * (commands.MAX_ENTRY_LENGTH + 1))
+    context = _make_context()
+
+    asyncio.run(commands.log_accomplishment(update, context))
+
+    update.message.reply_text.assert_called_once_with(
+        "That message is a bit long. Please keep it under 1000 characters."
+    )
+
+
+def test_log_saves_entry_and_confirms():
+    storage_client = MagicMock()
+    update = _make_update("/task Finish docs #writing")
+    context = _make_context(storage_client)
+
+    asyncio.run(commands.log_task(update, context))
+
+    storage_client.append_entry.assert_called_once()
+    update.message.reply_text.assert_called_with("Logged task: Finish docs #writing\nTags: #writing")
+
+
+def test_summary_without_storage():
+    update = _make_update("/week")
+    context = _make_context()
+
+    asyncio.run(commands.get_week_summary(update, context))
+
+    update.message.reply_text.assert_called_once_with(
+        "Storage is not configured yet, so I can't fetch entries. Please try again later."
+    )
+
+
+def test_summary_formats_entries():
+    storage_client = MagicMock()
+    storage_client.get_entries_by_date_range.return_value = [
+        {
+            "date": "2024-05-01",
+            "type": "accomplishment",
+            "text": "Shipped release",
+            "tags": "#release #infra",
+        },
+        {
+            "date": "2024-05-02",
+            "type": "task",
+            "text": "Schedule retro",
+            "tags": "",
+        },
+    ]
+    update = _make_update("/month")
+    context = _make_context(storage_client)
+
+    asyncio.run(commands.get_month_summary(update, context))
+
+    summary_text = "\n".join(line.strip() for line in update.message.reply_text.call_args.args[0].split("\n"))
+    assert summary_text.startswith("Entries from")
+    assert "• [Accomplishment] 2024-05-01: Shipped release (#release #infra)" in summary_text
+    assert "• [Task] 2024-05-02: Schedule retro" in summary_text

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+
+from src.bot import parsing
+
+
+def test_extract_tags():
+    text = "Wrapped up sprint items #backend #APIM and #infra"
+
+    tags = parsing.extract_tags(text)
+
+    assert tags == ["#backend", "#APIM", "#infra"]
+
+
+def test_extract_command_argument_removes_command():
+    message_text = "/log Implemented endpoint for #feature after refactor"
+
+    assert parsing.extract_command_argument(message_text) == "Implemented endpoint for #feature after refactor"
+
+
+def test_extract_command_argument_handles_empty_text():
+    assert parsing.extract_command_argument("/log") == ""
+    assert parsing.extract_command_argument("") == ""
+
+
+def test_normalize_entry_builds_expected_record(monkeypatch):
+    fixed_time = datetime(2024, 5, 1, 12, 0, 0)
+
+    record = parsing.normalize_entry(
+        "Implemented endpoint for #feature after refactor",
+        entry_type="accomplishment",
+        tags=["#feature"],
+        timestamp=fixed_time,
+    )
+
+    assert record == {
+        "timestamp": "2024-05-01T12:00:00",
+        "date": "2024-05-01",
+        "type": "accomplishment",
+        "text": "Implemented endpoint for #feature after refactor",
+        "tags": "#feature",
+        "source": "telegram",
+    }


### PR DESCRIPTION
## Summary
- add parsing utilities for extracting command text, tags, and normalized entry payloads
- implement command logging and summary behaviors with validation and storage integration hooks
- update tests to cover parsing, logging flows, and summary formatting; mark Command & Journal Agent complete in the phase plan

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693af7f9c458832babf239b1e3eb1707)