### PR TITLE
Add lightweight dashboard for long-form updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,19 @@ and the in-process scheduler when `REMINDERS_ENABLED=true`. To use an external c
 disable the scheduler via `REMINDERS_ENABLED=false` and invoke the image on your schedule with
 the same command.
 
+### 9. Lightweight web dashboard
+
+An experimental FastAPI dashboard is included for longer-form updates (goals, milestones,
+reviews, and richer entries) backed by the same Google Sheets storage. Launch it locally with:
+
+```bash
+uvicorn src.dashboard.app:create_app --factory --host 0.0.0.0 --port 8000
+```
+
+The dashboard uses your existing `.env` (including the service account settings) and writes to
+the same sheets as the Telegram bot. Keep it bound to `localhost` unless you add authentication
+in front of it.
+
 ## 📈 Operations & Monitoring
 
 - **Logs:** All components log to standard output with timezone-aware timestamps. For containers,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
     "APScheduler>=3.10.4",
     "pytz>=2024.1",
     "openai>=1.0.0",
+    "fastapi>=0.110.0",
+    "uvicorn>=0.30.0",
+    "jinja2>=3.1.0",
+    "python-multipart>=0.0.9",
 ]
 
 [project.optional-dependencies]

--- a/src/dashboard/__init__.py
+++ b/src/dashboard/__init__.py
@@ -1,0 +1,5 @@
+"""Dashboard package exposing the FastAPI application factory."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,0 +1,362 @@
+"""Lightweight FastAPI dashboard for longer-form data entry."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+from fastapi import FastAPI, Form, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from src.config import Config, load_config
+from src.storage.google_sheets_client import (
+    GOAL_MILESTONE_STATUSES,
+    GOAL_STATUSES,
+    GoogleSheetsClient,
+)
+
+TEMPLATES = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+REVIEW_TYPES = ["Midyear", "Quarterly", "Monthly Check-in", "Retrospective"]
+RATING_CHOICES = ["", "Exceptional", "Strong", "Solid", "Progressing", "Needs Support"]
+ENTRY_TYPES = [
+    ("accomplishment", "Accomplishment"),
+    ("task", "Task"),
+    ("idea", "Idea"),
+    ("reflection", "Reflection"),
+]
+
+
+def create_app(
+    config: Optional[Config] = None, sheets_client: Optional[GoogleSheetsClient] = None
+) -> FastAPI:
+    """Create and configure the FastAPI dashboard application."""
+
+    cfg = config or load_config()
+    client = sheets_client or GoogleSheetsClient(
+        spreadsheet_id=cfg.spreadsheet_id,
+        service_account_file=cfg.service_account_file,
+        service_account_json=cfg.service_account_json,
+    )
+
+    app = FastAPI(
+        title="Career Compass Dashboard",
+        description="Minimal web dashboard for longer-form updates",
+        version="0.1.0",
+        docs_url=None,
+        redoc_url=None,
+    )
+
+    def _render(template: str, request: Request, **context: Dict[str, object]) -> HTMLResponse:
+        return TEMPLATES.TemplateResponse(template, {"request": request, **context})
+
+    @app.get("/", response_class=HTMLResponse)
+    async def home(request: Request, success: str | None = None) -> HTMLResponse:
+        return _render("home.html", request, success=_success_message(success))
+
+    @app.get("/goals/new", response_class=HTMLResponse)
+    async def new_goal_form(request: Request) -> HTMLResponse:
+        return _render(
+            "goal_form.html",
+            request,
+            statuses=_ordered_goal_statuses(),
+            form_data={},
+        )
+
+    @app.post("/goals/new")
+    async def submit_goal(
+        request: Request,
+        title: str = Form(...),
+        description: str = Form(""),
+        status_value: str = Form("In Progress"),
+        goal_id: str = Form(""),
+        target_date: str = Form(""),
+        owner: str = Form(""),
+        notes: str = Form(""),
+        completion_percentage: str = Form(""),
+    ) -> HTMLResponse:
+        form_data = {
+            "title": title,
+            "description": description,
+            "status_value": status_value,
+            "goal_id": goal_id,
+            "target_date": target_date,
+            "owner": owner,
+            "notes": notes,
+            "completion_percentage": completion_percentage,
+        }
+
+        if status_value not in GOAL_STATUSES:
+            return _render(
+                "goal_form.html",
+                request,
+                statuses=_ordered_goal_statuses(),
+                form_data=form_data,
+                error="Choose a valid status",
+            )
+
+        goal_payload = {
+            "goal_id": _clean_text(goal_id),
+            "title": _clean_text(title),
+            "description": _clean_text(description),
+            "status": status_value,
+            "target_date": _clean_text(target_date),
+            "owner": _clean_text(owner),
+            "notes": _clean_text(notes),
+            "completion_percentage": _clean_text(completion_percentage),
+            "lifecycle_status": "Active",
+        }
+
+        try:
+            client.append_goal(goal_payload)
+        except ValueError as exc:  # noqa: BLE001
+            return _render(
+                "goal_form.html",
+                request,
+                statuses=_ordered_goal_statuses(),
+                form_data=form_data,
+                error=str(exc),
+            )
+
+        return RedirectResponse("/?success=goal", status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.get("/goals/milestones/new", response_class=HTMLResponse)
+    async def new_milestone_form(request: Request) -> HTMLResponse:
+        return _render(
+            "milestone_form.html",
+            request,
+            statuses=_ordered_milestone_statuses(),
+            form_data={},
+        )
+
+    @app.post("/goals/milestones/new")
+    async def submit_goal_milestone(
+        request: Request,
+        goal_id: str = Form(...),
+        title: str = Form(...),
+        target_date: str = Form(""),
+        status_value: str = Form("Not Started"),
+        completion_date: str = Form(""),
+        notes: str = Form(""),
+    ) -> HTMLResponse:
+        form_data = {
+            "goal_id": goal_id,
+            "title": title,
+            "target_date": target_date,
+            "status_value": status_value,
+            "completion_date": completion_date,
+            "notes": notes,
+        }
+
+        if status_value not in GOAL_MILESTONE_STATUSES:
+            return _render(
+                "milestone_form.html",
+                request,
+                statuses=_ordered_milestone_statuses(),
+                form_data=form_data,
+                error="Choose a valid milestone status",
+            )
+
+        milestone_payload = {
+            "goal_id": _clean_text(goal_id),
+            "title": _clean_text(title),
+            "target_date": _clean_text(target_date),
+            "completion_date": _clean_text(completion_date),
+            "status": status_value,
+            "notes": _clean_text(notes),
+        }
+
+        try:
+            client.append_goal_milestone(milestone_payload)
+        except ValueError as exc:  # noqa: BLE001
+            return _render(
+                "milestone_form.html",
+                request,
+                statuses=_ordered_milestone_statuses(),
+                form_data=form_data,
+                error=str(exc),
+            )
+
+        return RedirectResponse("/?success=milestone", status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.get("/reviews/goal", response_class=HTMLResponse)
+    async def new_goal_review(request: Request) -> HTMLResponse:
+        return _render(
+            "goal_review_form.html",
+            request,
+            review_types=REVIEW_TYPES,
+            ratings=RATING_CHOICES,
+            form_data={},
+        )
+
+    @app.post("/reviews/goal")
+    async def submit_goal_review(
+        request: Request,
+        goal_id: str = Form(...),
+        review_type: str = Form("Midyear"),
+        rating: str = Form(""),
+        notes: str = Form(""),
+        reviewed_on: str = Form(""),
+    ) -> HTMLResponse:
+        form_data = {
+            "goal_id": goal_id,
+            "review_type": review_type,
+            "rating": rating,
+            "notes": notes,
+            "reviewed_on": reviewed_on,
+        }
+
+        if review_type not in REVIEW_TYPES:
+            return _render(
+                "goal_review_form.html",
+                request,
+                review_types=REVIEW_TYPES,
+                ratings=RATING_CHOICES,
+                form_data=form_data,
+                error="Choose a valid review type",
+            )
+
+        review_payload = {
+            "goal_id": _clean_text(goal_id),
+            "review_type": review_type,
+            "rating": _clean_text(rating),
+            "notes": _clean_text(notes),
+            "reviewed_on": reviewed_on or date.today().isoformat(),
+        }
+
+        try:
+            client.append_goal_review(review_payload)
+        except ValueError as exc:  # noqa: BLE001
+            return _render(
+                "goal_review_form.html",
+                request,
+                review_types=REVIEW_TYPES,
+                ratings=RATING_CHOICES,
+                form_data=form_data,
+                error=str(exc),
+            )
+
+        return RedirectResponse("/?success=goal_review", status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.get("/evaluations/competency", response_class=HTMLResponse)
+    async def new_competency_evaluation(request: Request) -> HTMLResponse:
+        return _render(
+            "competency_evaluation_form.html",
+            request,
+            ratings=RATING_CHOICES,
+            form_data={},
+        )
+
+    @app.post("/evaluations/competency")
+    async def submit_competency_evaluation(
+        request: Request,
+        competency_id: str = Form(...),
+        rating: str = Form(""),
+        notes: str = Form(""),
+        evaluated_on: str = Form(""),
+    ) -> HTMLResponse:
+        form_data = {
+            "competency_id": competency_id,
+            "rating": rating,
+            "notes": notes,
+            "evaluated_on": evaluated_on,
+        }
+
+        evaluation_payload = {
+            "competency_id": _clean_text(competency_id),
+            "rating": _clean_text(rating),
+            "notes": _clean_text(notes),
+            "evaluated_on": evaluated_on or date.today().isoformat(),
+        }
+
+        try:
+            client.append_competency_evaluation(evaluation_payload)
+        except ValueError as exc:  # noqa: BLE001
+            return _render(
+                "competency_evaluation_form.html",
+                request,
+                ratings=RATING_CHOICES,
+                form_data=form_data,
+                error=str(exc),
+            )
+
+        return RedirectResponse("/?success=competency", status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.get("/entries/new", response_class=HTMLResponse)
+    async def new_entry_form(request: Request) -> HTMLResponse:
+        return _render(
+            "entry_form.html",
+            request,
+            entry_types=ENTRY_TYPES,
+            form_data={"entry_type": "accomplishment"},
+        )
+
+    @app.post("/entries/new")
+    async def submit_entry(
+        request: Request,
+        entry_type: str = Form("accomplishment"),
+        text: str = Form(...),
+        tags: str = Form(""),
+        source: str = Form("Dashboard"),
+    ) -> HTMLResponse:
+        form_data = {"entry_type": entry_type, "text": text, "tags": tags, "source": source}
+
+        if entry_type not in {choice for choice, _ in ENTRY_TYPES}:
+            return _render(
+                "entry_form.html",
+                request,
+                entry_types=ENTRY_TYPES,
+                form_data=form_data,
+                error="Choose a valid entry type",
+            )
+
+        now = datetime.utcnow()
+        entry_payload = {
+            "timestamp": now.isoformat(),
+            "date": now.date().isoformat(),
+            "type": entry_type,
+            "text": _clean_text(text),
+            "tags": _clean_text(tags),
+            "source": _clean_text(source) or "Dashboard",
+        }
+
+        try:
+            client.append_entry(entry_payload)
+        except ValueError as exc:  # noqa: BLE001
+            return _render(
+                "entry_form.html",
+                request,
+                entry_types=ENTRY_TYPES,
+                form_data=form_data,
+                error=str(exc),
+            )
+
+        return RedirectResponse("/?success=entry", status_code=status.HTTP_303_SEE_OTHER)
+
+    return app
+
+
+def _clean_text(value: str | None) -> str:
+    return value.strip() if value else ""
+
+
+def _ordered_goal_statuses() -> list[str]:
+    return sorted(GOAL_STATUSES)
+
+
+def _ordered_milestone_statuses() -> list[str]:
+    return sorted(GOAL_MILESTONE_STATUSES)
+
+
+def _success_message(code: str | None) -> str | None:
+    messages = {
+        "goal": "Goal saved to Google Sheets.",
+        "milestone": "Milestone saved to Google Sheets.",
+        "goal_review": "Goal review submitted.",
+        "competency": "Competency evaluation submitted.",
+        "entry": "Entry logged successfully.",
+    }
+    return messages.get(code or "")
+

--- a/src/dashboard/templates/base.html
+++ b/src/dashboard/templates/base.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Career Compass Dashboard</title>
+  <style>
+    :root {
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      color: #0f172a;
+      background: #f8fafc;
+    }
+    body {
+      margin: 0;
+      padding: 0;
+      background: #f8fafc;
+      color: #0f172a;
+    }
+    header {
+      background: #0f172a;
+      color: #f8fafc;
+      padding: 16px 24px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 20px;
+    }
+    main {
+      max-width: 960px;
+      margin: 32px auto;
+      padding: 0 16px 48px;
+    }
+    .card {
+      background: #ffffff;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+    }
+    .card h2 {
+      margin-top: 0;
+      font-size: 18px;
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 12px;
+    }
+    .button-link {
+      text-decoration: none;
+      background: #0f766e;
+      color: #fff;
+      padding: 10px 14px;
+      border-radius: 10px;
+      font-weight: 600;
+      display: inline-block;
+    }
+    .button-link.secondary { background: #475569; }
+    .button-link:hover { background: #0d635d; }
+    .button-link.secondary:hover { background: #334155; }
+    .form-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 14px;
+    }
+    label {
+      font-weight: 600;
+      display: block;
+      margin-bottom: 6px;
+    }
+    input[type="text"], input[type="date"], textarea, select {
+      width: 100%;
+      padding: 10px;
+      border-radius: 8px;
+      border: 1px solid #cbd5e1;
+      background: #fff;
+      box-sizing: border-box;
+      font-size: 14px;
+    }
+    textarea { min-height: 140px; resize: vertical; }
+    .form-actions { margin-top: 18px; }
+    button {
+      background: #0f766e;
+      color: #fff;
+      border: none;
+      border-radius: 10px;
+      padding: 10px 16px;
+      font-size: 14px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    button.secondary { background: #475569; }
+    button:hover { background: #0d635d; }
+    button.secondary:hover { background: #334155; }
+    .alert {
+      padding: 12px 14px;
+      border-radius: 10px;
+      margin-bottom: 16px;
+      font-weight: 600;
+    }
+    .alert.success {
+      background: #ecfdf3;
+      color: #166534;
+      border: 1px solid #bbf7d0;
+    }
+    .alert.error {
+      background: #fef2f2;
+      color: #991b1b;
+      border: 1px solid #fecdd3;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Career Compass Dashboard</h1>
+  </header>
+  <main>
+    {% if success %}
+    <div class="alert success">{{ success }}</div>
+    {% endif %}
+    {% if error %}
+    <div class="alert error">{{ error }}</div>
+    {% endif %}
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/src/dashboard/templates/competency_evaluation_form.html
+++ b/src/dashboard/templates/competency_evaluation_form.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block content %}
+  <div class="card">
+    <h2>Competency evaluation</h2>
+    <form method="post" class="form">
+      <div class="form-grid">
+        <div>
+          <label for="competency_id">Competency ID *</label>
+          <input required type="text" name="competency_id" id="competency_id" value="{{ form_data.competency_id or '' }}" placeholder="COMM-01" />
+        </div>
+        <div>
+          <label for="rating">Rating</label>
+          <select name="rating" id="rating">
+            {% for option in ratings %}
+              <option value="{{ option }}" {% if form_data.rating == option %}selected{% endif %}>{{ option or 'Select rating (optional)' }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="evaluated_on">Evaluated on</label>
+          <input type="date" name="evaluated_on" id="evaluated_on" value="{{ form_data.evaluated_on or '' }}" />
+        </div>
+      </div>
+      <div style="margin-top: 12px;">
+        <label for="notes">Notes</label>
+        <textarea name="notes" id="notes" placeholder="Strengths, gaps, and examples">{{ form_data.notes or '' }}</textarea>
+      </div>
+      <div class="form-actions">
+        <button type="submit">Save evaluation</button>
+        <a class="button-link secondary" href="/">Back</a>
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/src/dashboard/templates/entry_form.html
+++ b/src/dashboard/templates/entry_form.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block content %}
+  <div class="card">
+    <h2>Log an entry</h2>
+    <form method="post" class="form">
+      <div class="form-grid">
+        <div>
+          <label for="entry_type">Type</label>
+          <select name="entry_type" id="entry_type">
+            {% for value, label in entry_types %}
+              <option value="{{ value }}" {% if form_data.entry_type == value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="tags">Tags</label>
+          <input type="text" name="tags" id="tags" value="{{ form_data.tags or '' }}" placeholder="#goal:G-2024-01 #comp:leadership" />
+        </div>
+        <div>
+          <label for="source">Source</label>
+          <input type="text" name="source" id="source" value="{{ form_data.source or 'Dashboard' }}" />
+        </div>
+      </div>
+      <div style="margin-top: 12px;">
+        <label for="text">Entry text *</label>
+        <textarea required name="text" id="text" placeholder="Longer-form update with details, stakeholders, and outcomes">{{ form_data.text or '' }}</textarea>
+      </div>
+      <div class="form-actions">
+        <button type="submit">Save entry</button>
+        <a class="button-link secondary" href="/">Back</a>
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/src/dashboard/templates/goal_form.html
+++ b/src/dashboard/templates/goal_form.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{% block content %}
+  <div class="card">
+    <h2>Create a goal</h2>
+    <form method="post" class="form">
+      <div class="form-grid">
+        <div>
+          <label for="title">Title *</label>
+          <input required type="text" name="title" id="title" value="{{ form_data.title or '' }}" placeholder="Launch the new onboarding flow" />
+        </div>
+        <div>
+          <label for="goal_id">Goal ID</label>
+          <input type="text" name="goal_id" id="goal_id" value="{{ form_data.goal_id or '' }}" placeholder="G-2024-01" />
+        </div>
+        <div>
+          <label for="status_value">Status</label>
+          <select name="status_value" id="status_value">
+            {% for status in statuses %}
+              <option value="{{ status }}" {% if form_data.status_value == status %}selected{% endif %}>{{ status }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="target_date">Target date</label>
+          <input type="date" name="target_date" id="target_date" value="{{ form_data.target_date or '' }}" />
+        </div>
+        <div>
+          <label for="owner">Owner</label>
+          <input type="text" name="owner" id="owner" value="{{ form_data.owner or '' }}" placeholder="Your name" />
+        </div>
+        <div>
+          <label for="completion_percentage">Completion %</label>
+          <input type="text" name="completion_percentage" id="completion_percentage" value="{{ form_data.completion_percentage or '' }}" placeholder="0" />
+        </div>
+      </div>
+      <div style="margin-top: 12px;">
+        <label for="description">Description</label>
+        <textarea name="description" id="description" placeholder="Context, success definition, and guardrails">{{ form_data.description or '' }}</textarea>
+      </div>
+      <div style="margin-top: 12px;">
+        <label for="notes">Notes</label>
+        <textarea name="notes" id="notes" placeholder="Dependencies, stakeholders, known risks">{{ form_data.notes or '' }}</textarea>
+      </div>
+      <div class="form-actions">
+        <button type="submit">Save goal</button>
+        <a class="button-link secondary" href="/">Back</a>
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/src/dashboard/templates/goal_review_form.html
+++ b/src/dashboard/templates/goal_review_form.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block content %}
+  <div class="card">
+    <h2>Submit a goal review</h2>
+    <form method="post" class="form">
+      <div class="form-grid">
+        <div>
+          <label for="goal_id">Goal ID *</label>
+          <input required type="text" name="goal_id" id="goal_id" value="{{ form_data.goal_id or '' }}" placeholder="G-2024-01" />
+        </div>
+        <div>
+          <label for="review_type">Review type</label>
+          <select name="review_type" id="review_type">
+            {% for option in review_types %}
+              <option value="{{ option }}" {% if form_data.review_type == option %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="rating">Rating</label>
+          <select name="rating" id="rating">
+            {% for option in ratings %}
+              <option value="{{ option }}" {% if form_data.rating == option %}selected{% endif %}>{{ option or 'Select rating (optional)' }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="reviewed_on">Reviewed on</label>
+          <input type="date" name="reviewed_on" id="reviewed_on" value="{{ form_data.reviewed_on or '' }}" />
+        </div>
+      </div>
+      <div style="margin-top: 12px;">
+        <label for="notes">Notes</label>
+        <textarea name="notes" id="notes" placeholder="Wins, risks, and next steps">{{ form_data.notes or '' }}</textarea>
+      </div>
+      <div class="form-actions">
+        <button type="submit">Submit review</button>
+        <a class="button-link secondary" href="/">Back</a>
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/src/dashboard/templates/home.html
+++ b/src/dashboard/templates/home.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block content %}
+  <div class="card">
+    <h2>Quick actions</h2>
+    <p>Capture detailed updates directly into Google Sheets without juggling bot commands.</p>
+    <div class="actions">
+      <a class="button-link" href="/entries/new">Log an entry</a>
+      <a class="button-link" href="/goals/new">Create a goal</a>
+      <a class="button-link" href="/goals/milestones/new">Add milestone</a>
+      <a class="button-link" href="/reviews/goal">Submit goal review</a>
+      <a class="button-link" href="/evaluations/competency">Competency check-in</a>
+    </div>
+  </div>
+  <div class="card">
+    <h2>What this dashboard does</h2>
+    <ul>
+      <li>Creates structured goals with statuses, target dates, and notes.</li>
+      <li>Captures goal milestones and review snapshots for longer-form reflections.</li>
+      <li>Logs accomplishments, tasks, ideas, and reflections with rich text.</li>
+      <li>Writes directly to the same Google Sheets that power the Telegram bot.</li>
+    </ul>
+  </div>
+  <div class="card">
+    <h2>Usage tips</h2>
+    <ul>
+      <li>Keep IDs consistent with your bot workflow (e.g., <code>G-2024-01</code>).</li>
+      <li>Dates accept YYYY-MM-DD; leave blank if you do not have a target yet.</li>
+      <li>Statuses are validated before saving to avoid breaking the Sheets schema.</li>
+    </ul>
+  </div>
+{% endblock %}

--- a/src/dashboard/templates/milestone_form.html
+++ b/src/dashboard/templates/milestone_form.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block content %}
+  <div class="card">
+    <h2>Add a milestone</h2>
+    <form method="post" class="form">
+      <div class="form-grid">
+        <div>
+          <label for="goal_id">Goal ID *</label>
+          <input required type="text" name="goal_id" id="goal_id" value="{{ form_data.goal_id or '' }}" placeholder="G-2024-01" />
+        </div>
+        <div>
+          <label for="title">Title *</label>
+          <input required type="text" name="title" id="title" value="{{ form_data.title or '' }}" placeholder="Ship onboarding beta" />
+        </div>
+        <div>
+          <label for="target_date">Target date</label>
+          <input type="date" name="target_date" id="target_date" value="{{ form_data.target_date or '' }}" />
+        </div>
+        <div>
+          <label for="completion_date">Completion date</label>
+          <input type="date" name="completion_date" id="completion_date" value="{{ form_data.completion_date or '' }}" />
+        </div>
+        <div>
+          <label for="status_value">Status</label>
+          <select name="status_value" id="status_value">
+            {% for status in statuses %}
+              <option value="{{ status }}" {% if form_data.status_value == status %}selected{% endif %}>{{ status }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div style="margin-top: 12px;">
+        <label for="notes">Notes</label>
+        <textarea name="notes" id="notes" placeholder="What is needed to complete this milestone?">{{ form_data.notes or '' }}</textarea>
+      </div>
+      <div class="form-actions">
+        <button type="submit">Save milestone</button>
+        <a class="button-link secondary" href="/">Back</a>
+      </div>
+    </form>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a FastAPI-powered dashboard with HTML forms for goals, milestones, reviews, competency evaluations, and entries
- include templates and styling for the new dashboard surfaces
- document how to launch the dashboard and add required dependencies

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941d0851e84832b879df5f260b7a48c)